### PR TITLE
bugfix/accurics_remediation_37307519096553254 - Auto Generated Pull Request From Accurics

### DIFF
--- a/aws/s3_bucket.tf
+++ b/aws/s3_bucket.tf
@@ -2,4 +2,12 @@ resource "aws_s3_bucket" "tenable_cs_demo_s3_bucket" {
   bucket = "tenablecsdemos3bucket"
   acl    = "public-read"
   tags   = var.default_tags
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Server-side encryption protects data at rest. Amazon S3 encrypts each object with a unique key. As an additional safeguard, it encrypts the key itself with a key that it rotates regularly. Amazon S3 server-side encryption uses one of the strongest block ciphers available to encrypt your data, 256-bit Advanced Encryption Standard (AES-256).
 In Terraform - 
 Add the 'server_side_encryption_configuration' block to ensure server side encryption is enabled. Set 'sse_alogrithm' set to 'AES256'.