### PR TITLE
bugfix/accurics_remediation_36431997322565035 - Auto Generated Pull Request From Accurics

### DIFF
--- a/azure/security_group.tf
+++ b/azure/security_group.tf
@@ -13,7 +13,7 @@ resource "azurerm_network_security_rule" "ssh_security_rule" {
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "22"
-  source_address_prefix       = "0.0.0.0/0"
+  source_address_prefix       = "10.0.0.0/24"
   destination_address_prefix  = "*"
   resource_group_name         = azurerm_resource_group.tenable_cs_demo_rg.name
   network_security_group_name = azurerm_network_security_group.tenable_cs_demo_sg_ssh.name


### PR DESCRIPTION
Disable direct SSH access to your Azure Virtual Machines from the Internet. After direct SSH access from the Internet is disabled, you have other options you can use to access these virtual machines for remote management: 

 - [Point-to-site VPN](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-howto-point-to-site-resource-manager-portal)

 - [Site-to-site VPN](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-howto-site-to-site-resource-manager-portal)

 - [ExpressRoute](https://docs.microsoft.com/en-us/azure/expressroute/).